### PR TITLE
Ensure custom PATH is always first

### DIFF
--- a/files/home/gonano/.bashrc
+++ b/files/home/gonano/.bashrc
@@ -26,16 +26,16 @@ if [[ -n $PATH ]]; then
         export PATH=${PATH}:
 fi
 
+# if we have a base bootstrap, then let's add that first
+if [ -d /data ]; then
+  export PATH=${PATH}/data/sbin:/data/bin:
+fi
+
 # set the ubuntu defaults
 export PATH=${PATH}/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # prefix ubuntu defaults with the gonano pkgsrc bootstrap
 export PATH=/opt/gonano/sbin:/opt/gonano/bin:${PATH}
-
-# if we have a base bootstrap, then let's add that first
-if [ -d /data ]; then
-        export PATH=/data/sbin:/data/bin:${PATH}
-fi
 
 # with the environment variables exported and the PATH set
 # we need to source any custom profile scripts

--- a/files/home/gonano/.bashrc
+++ b/files/home/gonano/.bashrc
@@ -31,11 +31,11 @@ if [ -d /data ]; then
   export PATH=${PATH}/data/sbin:/data/bin:
 fi
 
-# set the ubuntu defaults
-export PATH=${PATH}/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
 # prefix ubuntu defaults with the gonano pkgsrc bootstrap
-export PATH=/opt/gonano/sbin:/opt/gonano/bin:${PATH}
+export PATH=${PATH}/opt/gonano/sbin:/opt/gonano/bin
+
+# set the ubuntu defaults
+export PATH=${PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # with the environment variables exported and the PATH set
 # we need to source any custom profile scripts


### PR DESCRIPTION
This follows up on previous work that was intented to provide this
functionality.

This change will ensure that if a base bootstrap is present, the
bootstrap will inject it's path before ubuntu default path and the
gonano path, but will not hijack the custom path.
