### PR TITLE
Removing the creation of links to the /etc/ssl/certs folder because t…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,6 @@ RUN curl -s http://pkgsrc.nanobox.io/nanobox/gonano/Linux/bootstrap.tar.gz | tar
       /opt/gonano/share/examples \
       /opt/gonano/man
 
-# symlink certs folder from /etc/ssl/certs to /opt/gonano/etc/openssl/certs
-RUN rm -rf /opt/gonano/etc/openssl/certs/ && \
-    ln -sf /etc/ssl/certs /opt/gonano/etc/openssl/certs
-
 # add gonano binaries on path 
 ENV PATH /opt/gonano/sbin:/opt/gonano/bin:$PATH
 
@@ -53,10 +49,6 @@ RUN curl -s http://pkgsrc.nanobox.io/nanobox/base/Linux/bootstrap.tar.gz | tar -
       /data/opt/gonano/man \
       /data/var/db/pkgin/cache && \
     chown -R gonano:gonano /data
-
-# symlink certs folder from /etc/ssl/certs to /data/etc/openssl/certs
-RUN rm -rf /data/etc/openssl/certs/ && \
-    ln -sf /etc/ssl/certs /data/etc/openssl/certs
 
 # Copy files
 ADD files/. /


### PR DESCRIPTION
…hat is now in the creation of the pkgsrc bootstraps for /data and /opt/gonano
